### PR TITLE
Added feature to display number of crew members per year

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,18 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 ## License
 
 [MIT License](https://choosealicense.com/licenses/mit/)
+
+## New Features in Latest Version
+
+### Crew Members Analysis
+- Added the ability to display the number of crew members per year based on the data in the MongoDB collection.
+- The application now reads from a `keys_to_consider.csv` file to determine which keys to consider for counting crew members.
+
+
+### External Files Required
+
+#### keys_to_consider.csv
+- This external file is required for the new crew members analysis feature.
+- The file should contain the keys to consider for counting crew members.
+- Place this file in the root directory of the project for the script to access it.
+

--- a/keys_to_consider.csv
+++ b/keys_to_consider.csv
@@ -1,0 +1,30 @@
+keys_to_consider
+art department
+art direction
+assistant director
+camera and electrical department
+cast
+casting department
+casting director
+cinematographer
+composer
+costume department
+costume designer
+creator
+director
+editor
+editorial department
+location management
+make up
+miscellaneous crew
+music department
+producer
+production design
+production manager
+script department
+set decoration
+sound crew
+special effects
+stunt performer
+visual effects
+writer


### PR DESCRIPTION
## Introduction
This pull request adds the ability to display the number of crew members per year from a given MongoDB collection.

## Technical Details
- Implemented method to read `keys_to_consider.csv` file that contains the keys to consider for counting crew members.
- Added functionality to display the number of crew members per year based on the provided keys.

## README Changes
- Updated README to reflect the new features implemented.

## Issues Resolved
No associated issues resolved with this PR.